### PR TITLE
Fix Chrome DevTools MCP failure in CI

### DIFF
--- a/.claude/commands/triage-devtools.md
+++ b/.claude/commands/triage-devtools.md
@@ -1,7 +1,7 @@
 ---
 description: Run full triage pipeline for a Gutenberg bug report using Chrome DevTools MCP
-allowed_args: issue
-allowedTools:
+argument-hint: [issue-number]
+allowed-tools:
   - Bash
   - Read
   - Write

--- a/.claude/commands/triage-devtools.md
+++ b/.claude/commands/triage-devtools.md
@@ -173,3 +173,12 @@ Execute the reporting instructions and post the GitHub comment.
 - This command uses Chrome DevTools MCP for browser automation
 - For Playwright-based triage, use `/triage` instead
 - Only Step 3 uses a subagent - this is intentional for optimal cache/isolation balance
+
+## IMPORTANT: Do NOT use Playwright
+
+This workflow uses **Chrome DevTools MCP only**. Do NOT:
+- Read or reference `3-reproduce-playwright.md`
+- Use any `mcp__playwright__*` tools
+- Fall back to Playwright if DevTools fails
+
+If Chrome DevTools MCP is unavailable, **fail fast** - do not attempt alternatives.

--- a/.claude/commands/triage-devtools.md
+++ b/.claude/commands/triage-devtools.md
@@ -174,11 +174,17 @@ Execute the reporting instructions and post the GitHub comment.
 - For Playwright-based triage, use `/triage` instead
 - Only Step 3 uses a subagent - this is intentional for optimal cache/isolation balance
 
-## IMPORTANT: Do NOT use Playwright
+## IMPORTANT: Do NOT use Playwright or Other Browser Automation Fallbacks
 
 This workflow uses **Chrome DevTools MCP only**. Do NOT:
 - Read or reference `3-reproduce-playwright.md`
 - Use any `mcp__playwright__*` tools
 - Fall back to Playwright if DevTools fails
+- Use Puppeteer directly (via npm/npx or any other method)
+- Use Selenium, WebDriver, or any other browser automation library
+- Attempt to write custom browser automation scripts
 
-If Chrome DevTools MCP is unavailable, **fail fast** - do not attempt alternatives.
+If Chrome DevTools MCP is unavailable, **fail fast**:
+1. Write a findings.json with `result: "inconclusive"` and explain MCP was unavailable
+2. Post a GitHub comment explaining the failure
+3. **STOP** - do not attempt any alternatives or workarounds

--- a/.github/workflows/claude-triage-devtools.yml
+++ b/.github/workflows/claude-triage-devtools.yml
@@ -51,25 +51,44 @@ jobs:
                   fetch-depth: 1
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            - name: Install Chrome dependencies
+            - name: Setup Chrome for DevTools MCP
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y chromium-browser
-                  which chromium-browser && chromium-browser --version
-                  # Set Chrome path for MCP
-                  echo "CHROME_PATH=$(which chromium-browser)" >> $GITHUB_ENV
+                  # GitHub runners have Chrome pre-installed - use it instead of snap chromium
+                  # Snap chromium has sandbox restrictions that break in CI environments
+                  if command -v google-chrome &> /dev/null; then
+                    CHROME_BIN=$(which google-chrome)
+                    echo "Using pre-installed Google Chrome: $CHROME_BIN"
+                    google-chrome --version
+                  elif command -v google-chrome-stable &> /dev/null; then
+                    CHROME_BIN=$(which google-chrome-stable)
+                    echo "Using pre-installed Google Chrome Stable: $CHROME_BIN"
+                    google-chrome-stable --version
+                  else
+                    # Fallback: Install Chrome from Google's repository
+                    echo "Installing Google Chrome from official repository..."
+                    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+                    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+                    sudo apt-get update
+                    sudo apt-get install -y google-chrome-stable
+                    CHROME_BIN=$(which google-chrome-stable)
+                  fi
+                  echo "CHROME_PATH=$CHROME_BIN" >> $GITHUB_ENV
 
             - name: Install WordPress Playground CLI
               run: npm install -g @wp-playground/cli
 
             - name: Create MCP config for Chrome DevTools
               run: |
-                  cat > /tmp/mcp-config.json << 'EOF'
+                  # Create MCP config with CHROME_PATH passed to the server
+                  cat > /tmp/mcp-config.json << EOF
                   {
                     "mcpServers": {
                       "chrome-devtools": {
                         "command": "npx",
-                        "args": ["-y", "@anthropic-ai/chrome-devtools-mcp@latest", "--headless"]
+                        "args": ["-y", "@anthropic-ai/chrome-devtools-mcp@latest", "--headless"],
+                        "env": {
+                          "CHROME_PATH": "${CHROME_PATH}"
+                        }
                       },
                       "context7": {
                         "command": "npx",
@@ -78,6 +97,8 @@ jobs:
                     }
                   }
                   EOF
+                  echo "MCP config created with CHROME_PATH: ${CHROME_PATH}"
+                  cat /tmp/mcp-config.json
 
             - name: Run Claude Triage (Chrome DevTools)
               uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

- **Fix MCP server startup failure**: Use pre-installed Google Chrome instead of snap chromium (which has sandbox restrictions that break in CI)
- **Pass CHROME_PATH to MCP**: Ensure the Chrome DevTools MCP server knows where Chrome is installed
- **Prevent fallback behavior**: Explicitly prohibit Playwright, Puppeteer, Selenium, or any other browser automation fallbacks that waste tokens
- **Fix frontmatter**: Correct field names to match Claude Code standards (`argument-hint`, `allowed-tools`)

## Root Cause Analysis

From the failed run logs:
1. MCP server showed `status: "failed"` at initialization
2. Ubuntu 24.04's `chromium-browser` is a snap package with sandbox restrictions
3. `CHROME_PATH` env var wasn't passed to MCP subprocess
4. Subagent fell back to Puppeteer, wasting ~$1.66 in tokens

## Test plan

- [ ] Trigger a new triage run with `@claude-devtools` on an issue
- [ ] Verify MCP server shows `status: "running"` in logs
- [ ] Verify reproduction completes without falling back to alternatives

🤖 Generated with [Claude Code](https://claude.ai/code)