### PR TITLE
Fix Chrome DevTools MCP package name

### DIFF
--- a/.github/workflows/claude-triage-devtools.yml
+++ b/.github/workflows/claude-triage-devtools.yml
@@ -85,7 +85,7 @@ jobs:
                     "mcpServers": {
                       "chrome-devtools": {
                         "command": "npx",
-                        "args": ["-y", "@anthropic-ai/chrome-devtools-mcp@latest", "--headless"],
+                        "args": ["-y", "chrome-devtools-mcp@latest", "--headless", "--isolated"],
                         "env": {
                           "CHROME_PATH": "${CHROME_PATH}"
                         }


### PR DESCRIPTION
## Summary
- The package `@anthropic-ai/chrome-devtools-mcp` doesn't exist on npm
- Changed to the correct package: `chrome-devtools-mcp` from the ChromeDevTools team
- Added `--isolated` flag for cleaner npx execution in CI environments

## Root cause
From CI logs, the MCP server was failing at init because npx couldn't find the package. Running `npm view @anthropic-ai/chrome-devtools-mcp` returns a 404.

## Test plan
- [ ] Trigger the DevTools triage workflow on a test issue
- [ ] Verify MCP server starts successfully (no "status: failed" in logs)
- [ ] Confirm pre-flight check passes (`mcp__chrome-devtools__list_pages` succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)