### PR TITLE
Optimize triage cost: Haiku model + snapshot limits

### DIFF
--- a/.claude/commands/triage-devtools.md
+++ b/.claude/commands/triage-devtools.md
@@ -123,12 +123,22 @@ Execute the blueprint generation instructions.
 
 **IMPORTANT**: Spawn a subagent to isolate browser snapshot context from the main conversation.
 
+**CRITICAL COST OPTIMIZATION**: Use Haiku model and limit turns to control costs.
+
 ```
 Task tool with:
   subagent_type: "general-purpose"
+  model: "haiku"        # USE HAIKU - 10x cheaper than Sonnet for browser automation
+  max_turns: 20         # Limit turns to prevent runaway context accumulation
   description: "Reproduce bug with DevTools"
   prompt: |
     Reproduce the bug for issue #<issue> using Chrome DevTools MCP.
+
+    COST OPTIMIZATION RULES (CRITICAL):
+    1. MINIMIZE SNAPSHOTS: Only take_snapshot when you need to find an element. Maximum 5 snapshots.
+    2. USE evaluate_script: For simple interactions, use JavaScript directly instead of snapshot+click.
+    3. USE wait_for: Instead of snapshot to check if page loaded, use wait_for with expected text.
+    4. BATCH ACTIONS: Do multiple actions before taking another snapshot.
 
     FIRST: Verify Chrome DevTools MCP is available by calling mcp__chrome-devtools__list_pages.
     If this fails, write a findings.json with result="inconclusive" and error="Chrome DevTools MCP unavailable", then stop.
@@ -164,19 +174,54 @@ Execute the reporting instructions and post the GitHub comment.
 
 3. **Reduced overhead**: Only one subagent spawn instead of four
 
-## Token Savings Mechanism
+## Cost Optimization Strategy
 
-**Without subagent** (original approach):
-- Browser snapshots accumulate in main context
-- Each snapshot ~5-10KB of tokens
-- 10+ snapshots = 50-100KB+ accumulated
-- All this context is cached and re-read on each turn
+**Target cost: ~$0.20-0.30 per triage** (down from $2+ without optimization)
 
-**With subagent for Step 3**:
-- Browser snapshots stay in subagent context
-- Subagent completes and context is discarded
-- Main agent only sees final result summary
-- Steps 1, 2, 4 still benefit from caching
+### Key Optimizations:
+
+1. **Use Haiku for browser automation** (10x cheaper than Sonnet)
+   - Browser automation doesn't need Sonnet's reasoning power
+   - Haiku is sufficient for click/type/navigate operations
+   - Cost reduction: $2.00 → $0.20
+
+2. **Limit snapshots** (each snapshot = 2-5K tokens)
+   - Maximum 5 snapshots per reproduction
+   - Use `wait_for` instead of snapshot to check page state
+   - Use `evaluate_script` for direct DOM interaction
+
+3. **Limit subagent turns** (max_turns: 20)
+   - Prevents runaway context accumulation
+   - Each turn re-reads entire context (even cached = cost)
+
+4. **Subagent isolation** (still valuable)
+   - Browser snapshots stay in subagent context
+   - Main agent never sees the 50-100KB of snapshot data
+   - Subagent context discarded after completion
+
+### Why Snapshots Are Expensive:
+
+```
+Each snapshot = ~3K tokens
+20 snapshots = 60K tokens accumulated
+Each turn re-reads context (even cached)
+40 turns × 60K tokens = 2.4M cache reads
+2.4M × $0.30/1M = $0.72 just for cache reads!
+```
+
+### Token-Efficient Patterns:
+
+```javascript
+// EXPENSIVE: Snapshot → Find → Click (3K tokens per snapshot)
+take_snapshot()
+click(uid: "abc123")
+
+// CHEAP: Direct JavaScript (~100 tokens)
+evaluate_script({ function: "document.querySelector('button.save').click()" })
+
+// CHEAP: Wait for text instead of snapshot
+wait_for({ text: "Settings saved" })
+```
 
 ## Notes
 

--- a/.claude/workflows/triage/3-reproduce-devtools.md
+++ b/.claude/workflows/triage/3-reproduce-devtools.md
@@ -2,6 +2,43 @@
 
 Execute reproduction steps using Chrome DevTools MCP to verify Gutenberg bug reports.
 
+## ⚠️ COST OPTIMIZATION RULES (CRITICAL)
+
+**Each snapshot costs ~3K tokens. Minimize them aggressively.**
+
+| Rule | Why |
+|------|-----|
+| **Maximum 5 snapshots** | 20 snapshots = $1+ in token costs |
+| **Use `wait_for` over snapshot** | Check page state without 3K token cost |
+| **Use `evaluate_script` for simple clicks** | Direct JS is ~100 tokens vs 3K for snapshot+click |
+| **Batch actions between snapshots** | Do 3-5 actions per snapshot, not 1 |
+
+### Token-Efficient Patterns
+
+```javascript
+// ❌ EXPENSIVE: Snapshot for every click (3K tokens each)
+take_snapshot()  // 3K tokens
+click(uid)
+take_snapshot()  // 3K tokens
+click(uid)
+// Total: 6K+ tokens
+
+// ✅ CHEAP: Direct JavaScript (~100 tokens each)
+evaluate_script({ function: "document.querySelector('.save-btn').click()" })
+wait_for({ text: "Saved" })
+// Total: ~200 tokens
+```
+
+### When to Use Each Approach
+
+| Scenario | Use This |
+|----------|----------|
+| Check if page loaded | `wait_for({ text: "Expected text" })` |
+| Click a button with known selector | `evaluate_script` with querySelector |
+| Fill a form field | `fill` with uid from ONE snapshot |
+| Complex UI with unknown structure | `take_snapshot` (but only once!) |
+| Verify bug is visible | `take_snapshot` + `take_screenshot` |
+
 ## 3.1 Setup
 
 Create screenshots directory:
@@ -33,12 +70,22 @@ For each step in `reproduction.steps`, translate natural language into DevTools 
 | "Click the Save button" | `click` with uid |
 | "Notice that ..." | Check for element presence in snapshot |
 
-**Implementation flow:**
-1. Use `take_snapshot` to understand page structure (returns uid-based tree)
-2. Identify target element by uid from snapshot
-3. Perform action (navigate, fill, click, etc.)
-4. Don't snapshot after action unless needed for verification
-5. Only screenshot when bug/error is visible (see screenshot strategy below)
+**Implementation flow (COST-OPTIMIZED):**
+
+1. **Navigate to page** → Use `navigate_page`, then `wait_for` to confirm load (NOT snapshot)
+2. **First snapshot** → Take ONE snapshot to understand page structure
+3. **Batch multiple actions** → Use uids from that snapshot for 3-5 actions
+4. **Use evaluate_script for known patterns** → WordPress has predictable selectors:
+   - Save button: `document.querySelector('.editor-post-publish-button, .components-button.is-primary')`
+   - Block inserter: `document.querySelector('.block-editor-inserter__toggle')`
+   - Settings: `document.querySelector('[aria-label="Settings"]')`
+5. **Second snapshot** → Only if you need to find NEW elements not in first snapshot
+6. **Final snapshot + screenshot** → Only when bug is visible for evidence
+
+**Snapshot budget: 5 maximum**
+- Snapshot 1: Initial page structure
+- Snapshot 2-3: Only if navigating to completely different pages
+- Snapshot 4-5: Bug evidence (if reproduced)
 
 ## 3.3 Collect evidence
 
@@ -206,16 +253,67 @@ Stop the Playground instance:
 
 ## WordPress-Specific Patterns
 
-Common WordPress admin element patterns:
+### Direct JavaScript Selectors (USE THESE - No Snapshot Needed!)
 
-| Task | How to Find |
-|------|-------------|
-| Save button | Look for `button` with "Save" text in snapshot |
-| Settings input | Find `textbox` or `input` by label in snapshot |
-| Block inserter | Look for button with "Add" in name/description |
-| Site Editor navigation | Look for navigation landmarks in snapshot |
+```javascript
+// Block Editor - Common Actions
+evaluate_script({ function: `
+  // Publish/Update button
+  document.querySelector('.editor-post-publish-button')?.click()
+`})
 
-Use `take_snapshot` to discover the actual structure - returns compact uid-based tree.
+evaluate_script({ function: `
+  // Save draft
+  document.querySelector('.editor-post-save-draft')?.click()
+`})
+
+evaluate_script({ function: `
+  // Open block inserter
+  document.querySelector('.block-editor-inserter__toggle')?.click()
+`})
+
+evaluate_script({ function: `
+  // Open settings sidebar
+  document.querySelector('[aria-label="Settings"]')?.click()
+`})
+
+evaluate_script({ function: `
+  // Select a block by clicking it
+  document.querySelector('.wp-block-paragraph')?.click()
+`})
+
+// Site Editor - Common Actions
+evaluate_script({ function: `
+  // Save in Site Editor
+  document.querySelector('.edit-site-save-button__button')?.click()
+`})
+
+// Admin Pages
+evaluate_script({ function: `
+  // Submit form
+  document.querySelector('#submit, input[type="submit"]')?.click()
+`})
+```
+
+### When You DO Need a Snapshot
+
+| Situation | Why Snapshot is Needed |
+|-----------|----------------------|
+| Complex dynamic UI | Element IDs/classes are generated |
+| Need to read text content | Must inspect accessibility tree |
+| Unknown page structure | First time seeing this page |
+| Bug evidence | Need to capture exact UI state |
+
+### Fallback: Snapshot-Based Element Finding
+
+If evaluate_script doesn't work, THEN use snapshot:
+
+| Task | How to Find in Snapshot |
+|------|------------------------|
+| Save button | Look for `button` with "Save" text |
+| Settings input | Find `textbox` by label |
+| Block inserter | Look for button with "Add" in name |
+| Site Editor navigation | Look for navigation landmarks |
 
 ## Special Cases
 


### PR DESCRIPTION
## Summary

Reduce triage cost from **$2+ to ~$0.20-0.30** per run (10x improvement).

## Problem

The previous run cost $2.04 due to:
- **4M cache read tokens** - Snapshots accumulated and re-read every turn
- **77 tool calls** - Each re-reading the growing context  
- **21 snapshots** - Each adding ~3K tokens
- **Sonnet model** - Used for browser automation (overkill)

## Solution

### 1. Use Haiku for browser automation (10x cheaper)
```yaml
Task tool with:
  model: "haiku"  # NEW
```
Browser automation doesn't need Sonnet's reasoning power.

### 2. Limit subagent turns
```yaml
  max_turns: 20  # NEW - prevents runaway
```

### 3. Limit snapshots to 5 maximum
Each snapshot = ~3K tokens. Document "snapshot budget" approach.

### 4. Add evaluate_script patterns
Direct JavaScript is ~100 tokens vs 3K for snapshot+click:
```javascript
// Instead of: take_snapshot() → click(uid)
evaluate_script({ function: "document.querySelector('.save-btn').click()" })
```

### 5. Prefer wait_for over snapshot
Check page state without 3K token cost:
```javascript
wait_for({ text: "Settings saved" })  // ~50 tokens
// vs take_snapshot()                  // ~3000 tokens
```

## Files Changed

- `.claude/commands/triage-devtools.md` - Subagent config + cost docs
- `.claude/workflows/triage/3-reproduce-devtools.md` - Snapshot limits + JS patterns

## Test Plan

- [ ] Run triage on test issue
- [ ] Verify cost is under $0.50
- [ ] Verify Haiku model is used for subagent
- [ ] Verify reproduction still works correctly

## Expected Cost Breakdown

| Before | After |
|--------|-------|
| Sonnet: $2.03 | Haiku: ~$0.20 |
| 21 snapshots | 5 snapshots max |
| 77 tool calls | ~20 tool calls |

🤖 Generated with [Claude Code](https://claude.com/claude-code)