### PR TITLE
Add screenshot artifact upload and linking to triage comments

### DIFF
--- a/.claude/workflows/triage/3-reproduce.md
+++ b/.claude/workflows/triage/3-reproduce.md
@@ -290,3 +290,5 @@ Use `mcp__playwright__browser_snapshot` only as fallback when element cannot be 
 ```
 
 **Note**: Screenshots are only taken when the bug/error is visible. No intermediate navigation or action screenshots.
+
+**Artifact Upload**: Screenshots saved to `/tmp/triage/<issue>/screenshots/` are automatically uploaded as GitHub Actions artifacts after the triage completes. The workflow will update the issue comment with a link to download the screenshots.

--- a/.claude/workflows/triage/4-report.md
+++ b/.claude/workflows/triage/4-report.md
@@ -46,12 +46,13 @@ Use this concise format for GitHub comments:
 
 {1-2 sentence summary of what was tested and the result}
 
+<!-- SCREENSHOTS_PLACEHOLDER -->
+
 <details>
 <summary>Evidence</summary>
 
 **Network:** `{method} {endpoint}` → {status}
 **Console:** {key errors if any}
-**Screenshots:** {count} captured (only if bug reproduced and screenshots exist)
 
 </details>
 
@@ -64,6 +65,8 @@ Use this concise format for GitHub comments:
 ---
 <sub>Automated triage via WordPress Playground</sub>
 ```
+
+**Note:** The `<!-- SCREENSHOTS_PLACEHOLDER -->` marker is required. After posting the comment, the GitHub Actions workflow will automatically replace this placeholder with a "Screenshots" section containing a link to the uploaded screenshot artifacts (if any screenshots were captured).
 
 ## 4.4 Suspect Code Areas
 

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -91,3 +91,56 @@ jobs:
                   claude_args: |
                       --mcp-config /tmp/mcp-config.json
                       --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill,mcp__playwright__browser_navigate,mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_type,mcp__playwright__browser_press_key,mcp__playwright__browser_fill_form,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_console_messages,mcp__playwright__browser_network_requests,mcp__playwright__browser_wait_for,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_hover,mcp__playwright__browser_navigate_back,mcp__playwright__browser_close,mcp__context7"
+
+            - name: Upload screenshots artifact
+              id: upload_screenshots
+              uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+              if: always()
+              with:
+                  name: triage-screenshots-${{ github.event.issue.number }}
+                  path: /tmp/triage/${{ github.event.issue.number }}/screenshots/
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+            - name: Update comment with screenshot links
+              if: always() && steps.upload_screenshots.outputs.artifact-id
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const issueNumber = ${{ github.event.issue.number }};
+                      const artifactId = '${{ steps.upload_screenshots.outputs.artifact-id }}';
+                      const runId = '${{ github.run_id }}';
+                      const repo = context.repo;
+
+                      // Find comment with placeholder
+                      const comments = await github.rest.issues.listComments({
+                        owner: repo.owner,
+                        repo: repo.repo,
+                        issue_number: issueNumber,
+                      });
+
+                      const comment = comments.data.find(c =>
+                        c.body && c.body.includes('<!-- SCREENSHOTS_PLACEHOLDER -->')
+                      );
+
+                      if (!comment) {
+                        console.log('No comment with placeholder found');
+                        return;
+                      }
+
+                      // Replace placeholder with screenshot section
+                      const screenshotSection = `### 📸 Screenshots\n\nScreenshots are available as artifacts: [View screenshots](https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}/artifacts/${artifactId})`;
+                      const updatedBody = comment.body.replace(
+                        '<!-- SCREENSHOTS_PLACEHOLDER -->',
+                        screenshotSection
+                      );
+
+                      // Update comment
+                      await github.rest.issues.updateComment({
+                        owner: repo.owner,
+                        repo: repo.repo,
+                        comment_id: comment.id,
+                        body: updatedBody,
+                      });
+
+                      console.log(`Updated comment ${comment.id} with screenshot link`);


### PR DESCRIPTION
## What

Upload Playwright screenshots as GitHub Actions artifacts and link them in triage comments.

## Why

Screenshots captured during bug reproduction should be accessible to issue reviewers without manual intervention. Currently screenshots are saved locally but not exposed in the issue comment.

## How

1. Claude posts comment with `<!-- SCREENSHOTS_PLACEHOLDER -->` marker
2. Workflow uploads screenshots from `/tmp/triage/<issue>/screenshots/` as artifacts (90-day retention)
3. Workflow finds comment with placeholder and replaces it with formatted screenshot section containing direct artifact link

## Testing

1. Trigger the triage workflow on a test issue
2. Verify screenshots are captured during reproduction
3. Check that the artifact is uploaded with 90-day retention
4. Verify the comment is updated with the screenshot link
