### PR TITLE
Content Guidelines: use post meta with revisions instead of JSON blob

### DIFF
--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
@@ -83,31 +83,66 @@ class Gutenberg_Content_Guidelines_Post_Type {
 
 	/**
 	 * Register post meta fields with revision support.
-	 *
-	 * Standard categories are registered here. Block-specific meta keys
-	 * are not registered individually - they're handled dynamically via
-	 * the wp_post_revision_meta_keys filter.
 	 */
 	public static function register_post_meta() {
+		$meta_args = array(
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+			'revisions_enabled' => true,
+			'auth_callback'     => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'sanitize_callback' => 'sanitize_textarea_field',
+		);
+
 		// Register standard category meta.
 		foreach ( self::CATEGORY_META_KEYS as $category ) {
-			$meta_key = '_content_guideline_' . $category;
-
-			register_post_meta(
-				self::POST_TYPE,
-				$meta_key,
-				array(
-					'show_in_rest'      => true,
-					'single'            => true,
-					'type'              => 'string',
-					'revisions_enabled' => true,
-					'auth_callback'     => function () {
-						return current_user_can( 'manage_options' );
-					},
-					'sanitize_callback' => 'sanitize_textarea_field',
-				)
-			);
+			register_post_meta( self::POST_TYPE, '_content_guideline_' . $category, $meta_args );
 		}
+
+		// Register meta for content blocks.
+		foreach ( self::get_content_blocks() as $block_name ) {
+			register_post_meta( self::POST_TYPE, self::block_name_to_meta_key( $block_name ), $meta_args );
+		}
+	}
+
+	/**
+	 * Get block names that have content role attributes.
+	 *
+	 * @return array Block names with content role.
+	 */
+	public static function get_content_blocks() {
+		$content_blocks = array();
+		$registry       = WP_Block_Type_Registry::get_instance();
+
+		foreach ( $registry->get_all_registered() as $block_type ) {
+			if ( self::block_has_content_role( $block_type ) ) {
+				$content_blocks[] = $block_type->name;
+			}
+		}
+
+		return $content_blocks;
+	}
+
+	/**
+	 * Check if a block type has any attribute with content role.
+	 *
+	 * @param WP_Block_Type $block_type The block type to check.
+	 * @return bool True if block has content role attribute.
+	 */
+	private static function block_has_content_role( $block_type ) {
+		if ( empty( $block_type->attributes ) ) {
+			return false;
+		}
+
+		foreach ( $block_type->attributes as $attribute ) {
+			if ( isset( $attribute['role'] ) && 'content' === $attribute['role'] ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-post-type.php
@@ -22,6 +22,25 @@ class Gutenberg_Content_Guidelines_Post_Type {
 	const POST_TYPE = 'wp_guidelines';
 
 	/**
+	 * The standard guideline category meta keys.
+	 *
+	 * @var array
+	 */
+	const CATEGORY_META_KEYS = array(
+		'copy',
+		'images',
+		'site',
+		'other',
+	);
+
+	/**
+	 * Prefix for block-specific guideline meta keys.
+	 *
+	 * @var string
+	 */
+	const BLOCK_META_PREFIX = '_content_guideline_block_';
+
+	/**
 	 * Register the custom post type.
 	 */
 	public static function register() {
@@ -60,5 +79,69 @@ class Gutenberg_Content_Guidelines_Post_Type {
 		);
 
 		register_post_type( self::POST_TYPE, $args );
+	}
+
+	/**
+	 * Register post meta fields with revision support.
+	 *
+	 * Standard categories are registered here. Block-specific meta keys
+	 * are not registered individually - they're handled dynamically via
+	 * the wp_post_revision_meta_keys filter.
+	 */
+	public static function register_post_meta() {
+		// Register standard category meta.
+		foreach ( self::CATEGORY_META_KEYS as $category ) {
+			$meta_key = '_content_guideline_' . $category;
+
+			register_post_meta(
+				self::POST_TYPE,
+				$meta_key,
+				array(
+					'show_in_rest'      => true,
+					'single'            => true,
+					'type'              => 'string',
+					'revisions_enabled' => true,
+					'auth_callback'     => function () {
+						return current_user_can( 'manage_options' );
+					},
+					'sanitize_callback' => 'sanitize_textarea_field',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Convert a block name to a meta key.
+	 *
+	 * @param string $block_name The block name (e.g., 'core/paragraph').
+	 * @return string The meta key (e.g., '_content_guideline_block_core_paragraph').
+	 */
+	public static function block_name_to_meta_key( $block_name ) {
+		// Replace '/' with '_' to create a valid meta key.
+		$sanitized = str_replace( '/', '_', $block_name );
+		return self::BLOCK_META_PREFIX . $sanitized;
+	}
+
+	/**
+	 * Convert a meta key back to a block name.
+	 *
+	 * @param string $meta_key The meta key (e.g., '_content_guideline_block_core_paragraph').
+	 * @return string The block name (e.g., 'core/paragraph').
+	 */
+	public static function meta_key_to_block_name( $meta_key ) {
+		// Remove prefix and convert first '_' back to '/'.
+		$without_prefix = str_replace( self::BLOCK_META_PREFIX, '', $meta_key );
+		// Replace first underscore with '/' (namespace separator).
+		return preg_replace( '/_/', '/', $without_prefix, 1 );
+	}
+
+	/**
+	 * Check if a meta key is a block guideline meta key.
+	 *
+	 * @param string $meta_key The meta key to check.
+	 * @return bool True if it's a block guideline meta key.
+	 */
+	public static function is_block_meta_key( $meta_key ) {
+		return strpos( $meta_key, self::BLOCK_META_PREFIX ) === 0;
 	}
 }

--- a/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-rest-controller.php
+++ b/lib/experimental/content-guidelines/class-gutenberg-content-guidelines-rest-controller.php
@@ -22,17 +22,6 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 	protected $post_type = 'wp_guidelines';
 
 	/**
-	 * JSON encoding flags for consistent and secure encoding.
-	 *
-	 * - JSON_UNESCAPED_SLASHES: Prevents escaping forward slashes (cleaner output)
-	 * - JSON_HEX_TAG: Encodes < and > as \u003C and \u003E (XSS prevention)
-	 * - JSON_HEX_AMP: Encodes & as \u0026 (XSS prevention)
-	 *
-	 * @var int
-	 */
-	protected $json_encode_flags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP;
-
-	/**
 	 * Maximum length for guideline text strings.
 	 *
 	 * @var int
@@ -342,16 +331,20 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 
 		$post_id = wp_insert_post(
 			array(
-				'post_type'    => $this->post_type,
-				'post_status'  => isset( $prepared['status'] ) && 'published' === $prepared['status'] ? 'publish' : 'draft',
-				'post_title'   => __( 'Content Guidelines', 'gutenberg' ),
-				'post_content' => $this->encode_json_for_storage( $prepared['content'] ),
+				'post_type'   => $this->post_type,
+				'post_status' => isset( $prepared['status'] ) && 'published' === $prepared['status'] ? 'publish' : 'draft',
+				'post_title'  => __( 'Content Guidelines', 'gutenberg' ),
 			),
 			true
 		);
 
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;
+		}
+
+		// Save guideline categories to post meta.
+		if ( ! empty( $prepared['categories'] ) ) {
+			$this->save_guideline_categories_to_meta( $post_id, $prepared['categories'] );
 		}
 
 		$post = get_post( $post_id );
@@ -377,19 +370,19 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 
 		$prepared = $this->prepare_item_for_database( $request );
 
-		// Get existing content and merge with new content.
-		$existing_content = $this->decode_json_from_storage( $post->post_content );
-		$new_content      = array_merge( $existing_content, $prepared['content'] );
+		// Save guideline categories to post meta.
+		if ( ! empty( $prepared['categories'] ) ) {
+			$this->save_guideline_categories_to_meta( $post->ID, $prepared['categories'] );
+		}
 
-		$update_args = array(
-			'ID'           => $post->ID,
-			'post_content' => $this->encode_json_for_storage( $new_content ),
-		);
-
+		// Update post status if provided.
+		$update_args = array( 'ID' => $post->ID );
 		if ( isset( $prepared['status'] ) ) {
 			$update_args['post_status'] = 'published' === $prepared['status'] ? 'publish' : 'draft';
 		}
 
+		// Trigger a post update to create a revision with the meta changes.
+		// We update post_modified to ensure a revision is created.
 		$result = wp_update_post( $update_args, true );
 
 		if ( is_wp_error( $result ) ) {
@@ -524,7 +517,8 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$content = $this->decode_json_from_storage( $revision->post_content );
+		// Get guideline categories from revision meta.
+		$guideline_categories = $this->get_guideline_categories_from_meta( $revision->ID );
 
 		$author = get_user_by( 'id', $revision->post_author );
 
@@ -535,7 +529,7 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 			'date_gmt'             => mysql_to_rfc3339( $revision->post_date_gmt ),
 			'author'               => $revision->post_author,
 			'author_name'          => $author ? $author->display_name : __( 'Unknown', 'gutenberg' ),
-			'guideline_categories' => ! empty( $content['guideline_categories'] ) ? $content['guideline_categories'] : new stdClass(),
+			'guideline_categories' => ! empty( $guideline_categories ) ? $guideline_categories : new stdClass(),
 		);
 
 		return rest_ensure_response( $data );
@@ -605,11 +599,9 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $post, $request ) {
-		$content = $this->decode_json_from_storage( $post->post_content );
+		$guideline_categories = $this->get_guideline_categories_from_meta( $post->ID );
 
 		$author = get_user_by( 'id', $post->post_author );
-
-		$guideline_categories = ! empty( $content['guideline_categories'] ) ? $content['guideline_categories'] : array();
 
 		// Handle ?category filter - return only the requested category.
 		$category_filter = $request->get_param( 'category' );
@@ -643,6 +635,57 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Gets guideline categories from post meta.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array Guideline categories.
+	 */
+	protected function get_guideline_categories_from_meta( $post_id ) {
+		$category_labels = array(
+			'copy'   => __( 'Copy Guidelines', 'gutenberg' ),
+			'images' => __( 'Image Guidelines', 'gutenberg' ),
+			'site'   => __( 'Site Context', 'gutenberg' ),
+			'other'  => __( 'Other Guidelines', 'gutenberg' ),
+		);
+
+		$guideline_categories = array();
+
+		// Get standard categories.
+		foreach ( Gutenberg_Content_Guidelines_Post_Type::CATEGORY_META_KEYS as $category ) {
+			$meta_key = '_content_guideline_' . $category;
+			$value    = get_post_meta( $post_id, $meta_key, true );
+
+			$guideline_categories[ $category ] = array(
+				'label'      => $category_labels[ $category ],
+				'guidelines' => $value,
+			);
+		}
+
+		// Get block-specific guidelines from individual meta keys.
+		$all_meta = get_post_meta( $post_id );
+
+		$blocks = array();
+		foreach ( $all_meta as $meta_key => $meta_values ) {
+			if ( Gutenberg_Content_Guidelines_Post_Type::is_block_meta_key( $meta_key ) ) {
+				$block_name = Gutenberg_Content_Guidelines_Post_Type::meta_key_to_block_name( $meta_key );
+				$value      = isset( $meta_values[0] ) ? $meta_values[0] : '';
+
+				if ( ! empty( $value ) ) {
+					$blocks[ $block_name ] = array(
+						'guidelines' => $value,
+					);
+				}
+			}
+		}
+
+		if ( ! empty( $blocks ) ) {
+			$guideline_categories['blocks'] = $blocks;
+		}
+
+		return $guideline_categories;
+	}
+
+	/**
 	 * Prepares a single guidelines for database.
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -650,7 +693,7 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared = array(
-			'content' => array(),
+			'categories' => array(),
 		);
 
 		if ( isset( $request['status'] ) ) {
@@ -658,10 +701,45 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 		}
 
 		if ( isset( $request['guideline_categories'] ) ) {
-			$prepared['content']['guideline_categories'] = $this->sanitize_guideline_categories( $request['guideline_categories'] );
+			$prepared['categories'] = $this->sanitize_guideline_categories( $request['guideline_categories'] );
 		}
 
 		return $prepared;
+	}
+
+	/**
+	 * Saves guideline categories to post meta.
+	 *
+	 * @param int   $post_id    Post ID.
+	 * @param array $categories Sanitized guideline categories.
+	 */
+	protected function save_guideline_categories_to_meta( $post_id, $categories ) {
+		// Save standard categories.
+		foreach ( Gutenberg_Content_Guidelines_Post_Type::CATEGORY_META_KEYS as $category ) {
+			if ( isset( $categories[ $category ] ) ) {
+				$meta_key = '_content_guideline_' . $category;
+				$value    = isset( $categories[ $category ]['guidelines'] )
+					? $categories[ $category ]['guidelines']
+					: '';
+				update_post_meta( $post_id, $meta_key, $value );
+			}
+		}
+
+		// Handle block-specific guidelines as individual meta keys.
+		// No registration needed - just save directly, revisions handled via filter.
+		if ( isset( $categories['blocks'] ) && is_array( $categories['blocks'] ) ) {
+			foreach ( $categories['blocks'] as $block_name => $block_data ) {
+				$meta_key = Gutenberg_Content_Guidelines_Post_Type::block_name_to_meta_key( $block_name );
+				$value    = isset( $block_data['guidelines'] ) ? $block_data['guidelines'] : '';
+
+				if ( ! empty( $value ) ) {
+					update_post_meta( $post_id, $meta_key, $value );
+				} else {
+					// Remove meta if value is empty (block guideline deleted).
+					delete_post_meta( $post_id, $meta_key );
+				}
+			}
+		}
 	}
 
 	/**
@@ -757,35 +835,6 @@ class Gutenberg_Content_Guidelines_REST_Controller extends WP_REST_Controller {
 			return null;
 		}
 		return $post;
-	}
-
-	/**
-	 * Encodes data as JSON for storage in post_content.
-	 *
-	 * Uses consistent encoding flags and wp_slash() for WordPress database compatibility.
-	 * This ensures special characters (quotes, HTML entities) are properly escaped.
-	 *
-	 * @param array $data Data to encode.
-	 * @return string Slashed JSON string ready for wp_insert_post/wp_update_post.
-	 */
-	protected function encode_json_for_storage( $data ) {
-		return wp_slash( wp_json_encode( $data, $this->json_encode_flags ) );
-	}
-
-	/**
-	 * Decodes JSON from post_content with error handling.
-	 *
-	 * @param string $json_string JSON string to decode.
-	 * @return array Decoded array, or empty array if decoding fails.
-	 */
-	protected function decode_json_from_storage( $json_string ) {
-		$decoded = json_decode( $json_string, true );
-
-		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
-			return array();
-		}
-
-		return $decoded;
 	}
 
 	/**

--- a/lib/experimental/content-guidelines/index.php
+++ b/lib/experimental/content-guidelines/index.php
@@ -16,6 +16,9 @@ require_once __DIR__ . '/class-gutenberg-content-guidelines-admin-page.php';
 // Register CPT.
 add_action( 'init', array( 'Gutenberg_Content_Guidelines_Post_Type', 'register' ) );
 
+// Register post meta with revision support (must run after CPT registration).
+add_action( 'init', array( 'Gutenberg_Content_Guidelines_Post_Type', 'register_post_meta' ), 20 );
+
 // Register REST routes.
 add_action(
 	'rest_api_init',
@@ -28,3 +31,28 @@ add_action(
 // Register admin page.
 add_action( 'admin_menu', array( 'Gutenberg_Content_Guidelines_Admin_Page', 'register_menu' ) );
 add_action( 'admin_enqueue_scripts', array( 'Gutenberg_Content_Guidelines_Admin_Page', 'enqueue_scripts' ) );
+
+/**
+ * Add block guideline meta keys to the list of revisioned meta.
+ *
+ * This allows block-specific guidelines to be captured in revisions
+ * without needing to register each meta key individually.
+ *
+ * @param array $keys The meta keys to revision.
+ * @return array Modified meta keys.
+ */
+function gutenberg_content_guidelines_revision_meta_keys( $keys ) {
+	global $wpdb;
+
+	// Get all unique block guideline meta keys from the database.
+	$block_keys = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE meta_key LIKE %s",
+			$wpdb->esc_like( Gutenberg_Content_Guidelines_Post_Type::BLOCK_META_PREFIX ) . '%'
+		)
+	);
+
+	return array_unique( array_merge( $keys, $block_keys ) );
+}
+add_filter( 'wp_post_revision_meta_keys', 'gutenberg_content_guidelines_revision_meta_keys' );
+

--- a/lib/experimental/content-guidelines/index.php
+++ b/lib/experimental/content-guidelines/index.php
@@ -16,13 +16,12 @@ require_once __DIR__ . '/class-gutenberg-content-guidelines-admin-page.php';
 // Register CPT.
 add_action( 'init', array( 'Gutenberg_Content_Guidelines_Post_Type', 'register' ) );
 
-// Register post meta with revision support (must run after CPT registration).
-add_action( 'init', array( 'Gutenberg_Content_Guidelines_Post_Type', 'register_post_meta' ), 20 );
-
-// Register REST routes.
+// Register REST routes and post meta (at rest_api_init so block registry is available).
 add_action(
 	'rest_api_init',
 	function () {
+		Gutenberg_Content_Guidelines_Post_Type::register_post_meta();
+
 		$controller = new Gutenberg_Content_Guidelines_REST_Controller();
 		$controller->register_routes();
 	}
@@ -31,28 +30,4 @@ add_action(
 // Register admin page.
 add_action( 'admin_menu', array( 'Gutenberg_Content_Guidelines_Admin_Page', 'register_menu' ) );
 add_action( 'admin_enqueue_scripts', array( 'Gutenberg_Content_Guidelines_Admin_Page', 'enqueue_scripts' ) );
-
-/**
- * Add block guideline meta keys to the list of revisioned meta.
- *
- * This allows block-specific guidelines to be captured in revisions
- * without needing to register each meta key individually.
- *
- * @param array $keys The meta keys to revision.
- * @return array Modified meta keys.
- */
-function gutenberg_content_guidelines_revision_meta_keys( $keys ) {
-	global $wpdb;
-
-	// Get all unique block guideline meta keys from the database.
-	$block_keys = $wpdb->get_col(
-		$wpdb->prepare(
-			"SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE meta_key LIKE %s",
-			$wpdb->esc_like( Gutenberg_Content_Guidelines_Post_Type::BLOCK_META_PREFIX ) . '%'
-		)
-	);
-
-	return array_unique( array_merge( $keys, $block_keys ) );
-}
-add_filter( 'wp_post_revision_meta_keys', 'gutenberg_content_guidelines_revision_meta_keys' );
 


### PR DESCRIPTION
Refactor storage architecture from JSON in `post_content` to individual post meta fields with `revisions_enabled: true`. This follows the WP 6.4+ Footnotes pattern and provides atomic revision restore while maintaining discrete storage per category.

- Register standard categories (copy, images, site, other) as post meta
- Store block-specific guidelines as flat meta keys (e.g., `_content_guideline_block_core_paragraph`)
- Add `wp_post_revision_meta_keys` filter for dynamic block meta revision support
- Remove JSON encoding/decoding helpers (no longer needed)